### PR TITLE
Add income of münsters companies

### DIFF
--- a/gehaelter.csv
+++ b/gehaelter.csv
@@ -1,0 +1,13 @@
+Unternehmen,Name,Gehalt,Jahr
+Sparkasse Münsterland-Ost,Markus Schabel,593000,2013
+Landesbausparkasse, Dr. Gerhard Schlangen,506000,2013
+Stadtwerke Münster,Hennig Müller-Tengelmann,237000,2013
+Wirtschaftsförderung Münster,Dr. Thomas Robbers,230000,2013
+Oberbürgermeister,Markus Lewe,144000,2013
+Regierungspräsident,Dr. Reinhard Klenke,110000,2013
+Landschaftsverband Westfalen-Lippe,Dr. Wolfgang Kirschwerden,110000,2013
+Universität Münster, Prof. Dr. Ursula Nelles,136450,2013
+Fachhochschule Münster,Prof. Dr. Ute von Lojewski,110000,2013
+Halle Münsterland,Ursula Paschke,116000,2013
+Wohn- und Stadtbau,Klemens Nottenkemper,133000,2013
+Polizei Münster,Hubert Wimber,92000,2013

--- a/gehaelter.csv
+++ b/gehaelter.csv
@@ -11,3 +11,4 @@ Fachhochschule Münster,Prof. Dr. Ute von Lojewski,110000,2013
 Halle Münsterland,Ursula Paschke,116000,2013
 Wohn- und Stadtbau,Klemens Nottenkemper,133000,2013
 Polizei Münster,Hubert Wimber,92000,2013
+Flughafen Münster-Osnabrück,Prof. Gerd Stöwer,280987,2013


### PR DESCRIPTION
source:
http://www.wn.de/Mobil-Home/So-viel-verdienen-Spitzenkraefte-in-Muenster-Muensters-Sparkassen-Chef-toppt-Merkels-Gehalt-deutlich